### PR TITLE
Add option to define how installation occurs

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -88,7 +88,7 @@ html(lang='en')
               a._hero-download-button(href=replaceall('$RELEASE_VERSION', _BODY.hero.release.version, item.url))
                 i(class='text-3xl' class=item.icon)
                 div(class='align-middle text-left')
-                  div(class='text-lg') Download for
+                  div(class='text-lg')= item.howto
                   div(class='text-3xl -mt-2 font-bold')= item.os
         if _BODY.hero.poster
           div._hero-image-container

--- a/src/index.pug
+++ b/src/index.pug
@@ -88,7 +88,10 @@ html(lang='en')
               a._hero-download-button(href=replaceall('$RELEASE_VERSION', _BODY.hero.release.version, item.url))
                 i(class='text-3xl' class=item.icon)
                 div(class='align-middle text-left')
-                  div(class='text-lg')= item.howto
+                  if item.howto
+                    div(class='text-lg')= item.howto
+                  else
+                    div(class='text-lg') Download for
                   div(class='text-3xl -mt-2 font-bold')= item.os
         if _BODY.hero.poster
           div._hero-image-container


### PR DESCRIPTION
Added the `item.howto` option, if given the text will change from "Download for" to the value in `item.howto`. See an example of this for "Build from Source" in the `develop` branch of easyReflectometry https://easyscience.github.io/easyReflectometryWww/